### PR TITLE
Add table and list components

### DIFF
--- a/src/components/web/data/TBody.tsx
+++ b/src/components/web/data/TBody.tsx
@@ -1,0 +1,9 @@
+import React, { HTMLAttributes, ReactNode } from "react";
+
+export interface TBodyProps extends HTMLAttributes<HTMLTableSectionElement> {
+  children?: ReactNode;
+}
+
+export function TBody({ children, ...props }: TBodyProps) {
+  return <tbody {...props}>{children}</tbody>;
+}

--- a/src/components/web/data/THead.tsx
+++ b/src/components/web/data/THead.tsx
@@ -1,0 +1,13 @@
+import React, { HTMLAttributes, ReactNode } from "react";
+
+export interface THeadProps extends HTMLAttributes<HTMLTableSectionElement> {
+  children?: ReactNode;
+}
+
+export function THead({ children, ...props }: THeadProps) {
+  return (
+    <thead {...props} className={`bg-gray-100 text-left ${props.className ?? ""}`}>
+      {children}
+    </thead>
+  );
+}

--- a/src/components/web/data/Table.tsx
+++ b/src/components/web/data/Table.tsx
@@ -1,0 +1,16 @@
+import React, { TableHTMLAttributes, ReactNode } from "react";
+
+export interface TableProps extends TableHTMLAttributes<HTMLTableElement> {
+  children?: ReactNode;
+}
+
+export function Table({ children, ...props }: TableProps) {
+  return (
+    <table
+      {...props}
+      className={`min-w-full border-collapse ${props.className ?? ""}`}
+    >
+      {children}
+    </table>
+  );
+}

--- a/src/components/web/data/Td.tsx
+++ b/src/components/web/data/Td.tsx
@@ -1,0 +1,16 @@
+import React, { TdHTMLAttributes, ReactNode } from "react";
+
+export interface TdProps extends TdHTMLAttributes<HTMLTableCellElement> {
+  children?: ReactNode;
+}
+
+export function Td({ children, ...props }: TdProps) {
+  return (
+    <td
+      {...props}
+      className={`px-4 py-2 border-b border-gray-200 ${props.className ?? ""}`}
+    >
+      {children}
+    </td>
+  );
+}

--- a/src/components/web/data/Tr.tsx
+++ b/src/components/web/data/Tr.tsx
@@ -1,0 +1,17 @@
+import React, { HTMLAttributes, ReactNode } from "react";
+
+export interface TrProps extends HTMLAttributes<HTMLTableRowElement> {
+  children?: ReactNode;
+  hover?: boolean;
+}
+
+export function Tr({ children, hover = true, ...props }: TrProps) {
+  return (
+    <tr
+      {...props}
+      className={`${hover ? "hover:bg-gray-50" : ""} ${props.className ?? ""}`}
+    >
+      {children}
+    </tr>
+  );
+}

--- a/src/components/web/display/List.tsx
+++ b/src/components/web/display/List.tsx
@@ -1,0 +1,21 @@
+import React, { HTMLAttributes, ReactNode } from "react";
+
+export interface ListProps
+  extends HTMLAttributes<HTMLUListElement | HTMLOListElement> {
+  children?: ReactNode;
+  ordered?: boolean;
+}
+
+export function List({ children, ordered = false, ...props }: ListProps) {
+  const Component: any = ordered ? "ol" : "ul";
+  return (
+    <Component
+      {...props}
+      className={`list-inside ${ordered ? "list-decimal" : "list-disc"} ${
+        props.className ?? ""
+      }`}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/src/components/web/display/ListItem.tsx
+++ b/src/components/web/display/ListItem.tsx
@@ -1,0 +1,13 @@
+import React, { LiHTMLAttributes, ReactNode } from "react";
+
+export interface ListItemProps extends LiHTMLAttributes<HTMLLIElement> {
+  children?: ReactNode;
+}
+
+export function ListItem({ children, ...props }: ListItemProps) {
+  return (
+    <li {...props} className={`my-1 ${props.className ?? ""}`}>
+      {children}
+    </li>
+  );
+}

--- a/src/components/web/index.tsx
+++ b/src/components/web/index.tsx
@@ -68,6 +68,16 @@ export type { ViewProps as CViewProps } from "./core/View";
 // Data
 // export { Chart, ChartError } from "./data/Chart";
 // export type { ChartProps } from "./data/Chart";
+export { Table } from "./data/Table";
+export type { TableProps } from "./data/Table";
+export { THead } from "./data/THead";
+export type { THeadProps } from "./data/THead";
+export { TBody } from "./data/TBody";
+export type { TBodyProps } from "./data/TBody";
+export { Tr } from "./data/Tr";
+export type { TrProps } from "./data/Tr";
+export { Td } from "./data/Td";
+export type { TdProps } from "./data/Td";
 
 // Display
 export { Bold, B } from "./display/Bold";
@@ -101,6 +111,10 @@ export type { TitleProps } from "./display/Title";
 
 export { InlineMath, Math } from "./display/InlineMath";
 export { BlockMath } from "./display/BlockMath";
+export { List } from "./display/List";
+export type { ListProps } from "./display/List";
+export { ListItem } from "./display/ListItem";
+export type { ListItemProps } from "./display/ListItem";
 
 // Feedback
 export { Message } from "./feedback/Message";


### PR DESCRIPTION
## Summary
- add Table components (Table, THead, TBody, Tr, Td)
- add List and ListItem components
- export newly added components

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npx tsc --noEmit` *(fails: cannot find module errors)*

------
https://chatgpt.com/codex/tasks/task_e_684303562f08832792d186e6b7b1162f