### PR TITLE
Fix hydration mismatch by deriving accent server side

### DIFF
--- a/src/hooks/useAccent.tsx
+++ b/src/hooks/useAccent.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { TailwindColorName } from "api/components/web/core/Text";
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useMemo } from "react";
 import { usePath } from "./usePath";
 
 export type AccentColor = TailwindColorName;
@@ -9,30 +9,27 @@ export const AccentContext = createContext<AccentColor | null>(null);
 
 export const AccentProvider = ({ children }: { children: React.ReactNode }) => {
   const pathname = usePath();
-  const [accent, setAccent] = useState<AccentColor>("blue");
-  useEffect(() => {
+
+  const accent = useMemo<AccentColor>(() => {
     if (pathname) {
       const path = pathname.split("/").filter((s) => s.trim() !== "");
       if (path.length > 0) {
         switch (path[0]) {
           case "lexos":
-            setAccent("slate");
-            break;
+            return "slate";
           case "lexicon":
-            setAccent("amber");
-            break;
+            return "amber";
           case "learn":
-            setAccent("indigo");
-            break;
+            return "indigo";
           case "mark":
-            setAccent("red");
-            break;
+            return "red";
           default:
-            setAccent("blue");
+            return "blue";
         }
       }
     }
-  }, [accent, pathname]);
+    return "blue";
+  }, [pathname]);
 
   return (
     <AccentContext.Provider value={accent}>{children}</AccentContext.Provider>

--- a/src/hooks/usePath.ts
+++ b/src/hooks/usePath.ts
@@ -1,11 +1,5 @@
-import { useState, useEffect } from "react";
+import { usePathname } from "next/navigation";
 
 export function usePath() {
-  const [path, setPath] = useState<string | null>(null);
-
-  useEffect(() => {
-    setPath(window.location.pathname);
-  }, []);
-
-  return path;
+  return usePathname();
 }


### PR DESCRIPTION
## Summary
- compute accent color directly from pathname using useMemo
- leverage `usePathname` from Next.js in `usePath` helper

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6843044fd260832783bf12d24732839f