### PR TITLE
Improve button styles

### DIFF
--- a/src/components/web/attributes/CustomAttribute.tsx
+++ b/src/components/web/attributes/CustomAttribute.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { ReactNode, useEffect, useState } from "react";
+import React, { ReactNode, useMemo } from "react";
 import { Flex } from "../layout/Flex";
 
 export type AttributeWidth =
@@ -28,41 +28,26 @@ export function WidthProvider({
   width: AttributeWidth;
   children: ReactNode;
 }) {
-  const [containerWidth, setContainerWidth] = useState<string | number | null>(
-    null,
-  );
-  useEffect(() => {
+  const style = useMemo(() => {
     switch (width) {
       case "full":
-        setContainerWidth("100%");
-        break;
+        return { width: "100%" };
       case "fit":
-        setContainerWidth("fit-content");
-        break;
+        return { width: "fit-content" };
       case "auto":
-        setContainerWidth("auto");
-        break;
+        return { width: "auto" };
       case "short":
-        setContainerWidth(200);
-        break;
+        return { width: 200, minWidth: 200 };
       case "medium":
-        setContainerWidth(270);
-        break;
+        return { width: 270, minWidth: 270 };
       case "long":
-        setContainerWidth(350);
-        break;
+        return { width: 350, minWidth: 350 };
+      default:
+        return {};
     }
   }, [width]);
+
   return (
-    <Flex
-      style={{
-        minWidth:
-          typeof containerWidth === "number" ? containerWidth : undefined,
-        width: containerWidth ?? undefined,
-        maxWidth: "100%",
-      }}
-    >
-      {children}
-    </Flex>
+    <Flex style={{ maxWidth: "100%", ...style }}>{children}</Flex>
   );
 }

--- a/src/components/web/input/Button.tsx
+++ b/src/components/web/input/Button.tsx
@@ -4,12 +4,12 @@ import { Button as CoreButton } from "../core/Button";
 import { AttributeWidth, WidthProvider } from "../attributes/CustomAttribute";
 import { Text } from "../display/Text";
 import { useAccent } from "../../../hooks/useAccent";
+import clsx from "clsx";
 
 export type ButtonStyle = "primary" | "secondary" | "outline" | "link";
 export type ButtonContent = "icon" | "text";
 
-export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   textContent?: string;
   children?: ReactNode;
   disabled?: boolean;
@@ -30,36 +30,40 @@ export function Button({
   ...props
 }: ButtonProps) {
   const accent = useAccent();
+
+  const base = clsx(
+    "flex items-center font-semibold transition-all duration-150 ease-in-out focus-visible:ring-4 outline-none",
+    `focus-visible:ring-${accent}-300`,
+    !disabled && "active:scale-[0.98]",
+    disabled && "opacity-50 cursor-not-allowed",
+    `justify-${textAlign}`,
+  );
+
+  const sizeCls =
+    buttonContent === "icon"
+      ? "rounded-full justify-center items-center size-12"
+      : "px-4 py-2 rounded-lg";
+
+  const styleCls = (() => {
+    switch (buttonStyle) {
+      case "secondary":
+        return "bg-gray-100 hover:bg-gray-200 text-gray-900 shadow-sm";
+      case "outline":
+        return `bg-white border-2 border-${accent}-400 text-${accent}-500 hover:bg-${accent}-50`;
+      case "link":
+        return `bg-transparent text-${accent}-600 hover:underline p-0`;
+      default:
+        return `bg-${accent}-600 hover:bg-${accent}-700 text-white shadow-md`;
+    }
+  })();
+
   return (
     <WidthProvider width={buttonContent === "icon" ? "fit" : width}>
       <CoreButton
         {...props}
         disabled={disabled}
-        className={[
-          `flex transition-all duration-150 ease-in-out outline-0 focus-visible:ring-4 focus-visible:ring-${accent}-300 ${!disabled ? "active:scale-[0.98]" : ""} font-semibold flex-grow items-center`,
-          buttonContent === "text"
-            ? "px-4 py-2 rounded-xl w-fit"
-            : "rounded-full items-center justify-center size-12",
-          buttonStyle === "primary"
-            ? `bg-${accent}-600 hover:bg-${accent}-700 text-white shadow-md w-full`
-            : "",
-          buttonStyle === "secondary"
-            ? `bg-gray-100 hover:bg-gray-200 text-gray-900 shadow-sm w-full`
-            : "",
-          buttonStyle === "outline"
-            ? `bg-white border-2 border-${accent}-400 text-${accent}-500 hover:bg-${accent}-50 w-full`
-            : "",
-          buttonStyle === "link"
-            ? `text-${accent}-600 hover:underline p-0`
-            : "",
-          disabled ? "opacity-50" : "",
-          `justify-${textAlign}`,
-          props.className ?? "",
-        ].join(" ")}
-        style={{
-          cursor: disabled ? "not-allowed" : "pointer",
-          ...props.style,
-        }}
+        className={clsx(base, sizeCls, styleCls, props.className)}
+        style={{ cursor: disabled ? "not-allowed" : "pointer", ...props.style }}
       >
         {children}
         {textContent && (


### PR DESCRIPTION
## Summary
- refactor `<Button>` for consistent styling across variants
- simplify `WidthProvider` to compute styles with `useMemo`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430ae2534c83278655163348070347